### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -12,6 +12,6 @@
       "{workspaceRoot}/.github/workflows/ci.yml"
     ]
   },
-  "nxCloudId": "674f53c7d65714bfee93e43f",
+  "nxCloudId": "677c1109e4f690f5052908ad",
   "nxCloudUrl": "https://staging.nx.app"
 }

--- a/nx.json
+++ b/nx.json
@@ -12,6 +12,6 @@
       "{workspaceRoot}/.github/workflows/ci.yml"
     ]
   },
-  "nxCloudId": "677c1109e4f690f5052908ad",
-  "nxCloudUrl": "https://staging.nx.app"
+  "nxCloudId": "6787f8d46ea8b82ac93b25b8",
+  "nxCloudUrl": "http://localhost:4202"
 }

--- a/nx.json
+++ b/nx.json
@@ -12,6 +12,6 @@
       "{workspaceRoot}/.github/workflows/ci.yml"
     ]
   },
-  "nxCloudId": "6787f8d46ea8b82ac93b25b8",
+  "nxCloudId": "67883769e3062d6bf33806d9",
   "nxCloudUrl": "http://localhost:4202"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://staging.nx.app/orgs/677c1101e4f690f5052908ab/workspaces/677c1109e4f690f5052908ad

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.