### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -24,7 +24,7 @@
       "inputs": ["production", "^production"]
     }
   },
-  "nxCloudId": "6786c6f831c773103b439c24",
+  "nxCloudId": "6787e5086ea8b82ac93b25af",
   "nxCloudUrl": "http://localhost:4202",
   "test": "2",
   "plugins": [


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
http://localhost:4202/orgs/6787e5006ea8b82ac93b25ad/workspaces/6787e5086ea8b82ac93b25af

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.